### PR TITLE
fix: rename secret name for PAT

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
       
       - name: 设置 Deno
         uses: denoland/setup-deno@v1


### PR DESCRIPTION
secret name should not start with "GITHUB_"

## Summary by Sourcery

CI:
- Renames the secret used for the personal access token (PAT) in the monitor workflow.